### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/packages/restlette/package.json
+++ b/packages/restlette/package.json
@@ -32,6 +32,7 @@
     "express": "^4.17.17",
     "fastify": "^5.2.1",
     "log4js": "^6.9.1",
-    "swagger-ui-express": "^4.1.7"
+    "swagger-ui-express": "^4.1.7",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/packages/restlette/src/index.ts
+++ b/packages/restlette/src/index.ts
@@ -1,10 +1,16 @@
 import express, {RequestHandler, Router} from "express";
+import rateLimit from "express-rate-limit";
 import Log4js from "log4js";
 import swaggerUi, {JsonObject} from "swagger-ui-express";
 import {Crud} from "./crud.js";
 import {paths} from "./swagger";
 
 const logger = Log4js.getLogger("meshql/restlette");
+
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
 
 const swaggerOptions = (apiPath: string, port: number, schema: Record<string, any>) => ({
     openapi: "3.0.0",
@@ -59,6 +65,7 @@ export function init<I>(
     const swaggerDoc: JsonObject = swaggerOptions(apiPath, port, jsonSchema);
     const router = createRestletteRouter(apiPath, crud);
 
+    app.use(limiter);
     app.use(apiPath, router);
     app.get(`${apiPath}/api-docs/swagger.json`, (req:express.Request, res:express.Response) => res.json(swaggerDoc));
 


### PR DESCRIPTION
Potential fix for [https://github.com/tsmarsh/meshql/security/code-scanning/3](https://github.com/tsmarsh/meshql/security/code-scanning/3)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to set up rate limiting middleware easily. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to all routes in the application.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `packages/restlette/src/index.ts` file.
3. Set up the rate limiter middleware.
4. Apply the rate limiter middleware to the Express application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
